### PR TITLE
Update yargs to ^15.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
 	"scripts": {},
 	"dependencies": {
 		"n-readlines": "^0.2.8",
-		"yargs": "^10.0.0"
+		"yargs": "^15.3.0"
 	}
 }


### PR DESCRIPTION
This resolves the transitive dependency on mem@^1.1.0, which is affected by [WS-2018-0236](https://vuln.whitesourcesoftware.com/?query=WS-2018-0236) and was patched in 4.0.0.

This transitive dependency comes from os-locale@^2.0.0, which is a dependency of yargs@^10.0.0.